### PR TITLE
Add required fields to OpenAPI specs for client integration

### DIFF
--- a/openapi/bull-bear.yml
+++ b/openapi/bull-bear.yml
@@ -74,6 +74,18 @@ components:
         ticker:
           type: string
           description: Stock ticker symbol related to the bull/bear case.
+        securities:
+          type: array
+          description: Company securities
+          items:
+            type: object
+            properties:
+              exchange:
+                type: string
+                description: Exchange on which the security is listed
+              symbol:
+                type: string
+                description: Ticker symbol for the security
         updated:
           type: integer
           format: int64

--- a/openapi/calendar-v2.yml
+++ b/openapi/calendar-v2.yml
@@ -881,6 +881,7 @@ paths:
           - pt_current
           - rating_prior
           - pt_prior
+          - pt_pct_change
           - url
           - url_calendar
           - url_news
@@ -2172,6 +2173,9 @@ components:
         description:
           type: string
           description: Event Description
+        event_category:
+          type: string
+          description: Category of the economic event
     guidance:
       type: object
       properties:
@@ -2623,6 +2627,10 @@ components:
           description: Analyst's prior price target, adjusted to account for stock
             splits and stock dividends. If none are applicable, the pt_prior value
             is used.
+          format: float
+        pt_pct_change:
+          type: string
+          description: Percentage change in price target from prior to current
           format: float
         url:
           type: string


### PR DESCRIPTION
This PR adds the required fields requested by Alrajhi:

- Add securities object to Bull-Bear API response schema
- Add pt_pct_change field to Ratings API response schema and fields list
- Add event_category field to Economics API response schema

Related to: [Emily's request for Alrajhi integration]